### PR TITLE
avoid writing into the DataModel from another thread - 1.0.2

### DIFF
--- a/com.mir.urcap.MiRintegration/pom.xml
+++ b/com.mir.urcap.MiRintegration/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.mir.urcap</groupId>
 	<artifactId>MiRintegration</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>MiRintegration</name>
 	<packaging>bundle</packaging>
 

--- a/com.mir.urcap.MiRintegration/src/main/java/com/mir/urcap/MiRintegration/program/MirReadRegisterProgramNodeView.java
+++ b/com.mir.urcap.MiRintegration/src/main/java/com/mir/urcap/MiRintegration/program/MirReadRegisterProgramNodeView.java
@@ -27,6 +27,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 
 import com.mir.urcap.MiRintegration.common.UIComponentFactory;
 import com.mir.urcap.MiRintegration.style.Style;
@@ -247,12 +248,12 @@ public class MirReadRegisterProgramNodeView implements SwingProgramNodeView<MirR
 		clearInputVariableName();
 		clearErrors();
 		updateVariablesComboBox();
-		CompletableFuture.runAsync(new Runnable() {
+		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
 				updateRegistersComboBox();				
 			}
-		});
+		});		
 	}
 	
 	public void setNewVariable(String variable) {

--- a/com.mir.urcap.MiRintegration/src/main/java/com/mir/urcap/MiRintegration/program/MirWriteRegisterProgramNodeContribution.java
+++ b/com.mir.urcap.MiRintegration/src/main/java/com/mir/urcap/MiRintegration/program/MirWriteRegisterProgramNodeContribution.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.concurrent.CompletableFuture;
 
+import javax.swing.SwingUtilities;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -63,7 +65,7 @@ public class MirWriteRegisterProgramNodeContribution implements ProgramNodeContr
 
 	@Override
 	public void openView() {
-		CompletableFuture.runAsync(new Runnable() {
+		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
 				view.updateRegistersComboBox();
@@ -74,7 +76,7 @@ public class MirWriteRegisterProgramNodeContribution implements ProgramNodeContr
 					view.setValue(getDoubleValue().toString());
 				}								
 			}
-		});
+		});		
 	}
 
 	@Override


### PR DESCRIPTION
By using the the SwingUtility invokeLater. The write to the DataModel is now performed from the Swing thread.